### PR TITLE
Update shift?+ctrl+k|q to match notepad++

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,12 +115,12 @@
             },
             {
                 "key": "ctrl+q",
-                "command": "editor.action.addCommentLine",
+                "command": "editor.action.commentLine",
                 "when": "editorTextFocus && !editorReadonly"
             },
             {
                 "key": "ctrl+shift+q",
-                "command": "editor.action.removeCommentLine",
+                "command": "editor.action.blockComment",
                 "when": "editorTextFocus && !editorReadonly"
             },
             {
@@ -134,7 +134,7 @@
             },
             {
                 "key": "ctrl+shift+k",
-                "command": "editor.action.blockComment",
+                "command": "editor.action.removeCommentLine",
                 "when": "editorTextFocus && !editorReadonly"
             },
             {


### PR DESCRIPTION
In notepad++ this works as follows:

  * ctrl+q       : toggle line comment
  * ctrl+shift+q : add block comment
  * ctrl+k       : add line comment
  * ctrl+shift+k : if present, remove line comment, otherwise,  remove enclosing block comment

This patch changes those key bindings to match that more closely.

For reference, notepad++'s default keybindings are defined here:
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/8dea25feb53f5162dc6bece267b3152d2532221f/PowerEditor/src/Parameters.cpp#L144-L148
 
Note that the constants in the file linked above are namedunintuitively:
  * IDM_EDIT_BLOCK_*  : line comment actions.
  * IDM_EDIT_STREAM_* : block comment actions.
See https://github.com/notepad-plus-plus/notepad-plus-plus/blob/ec340000ccde72debc8d0ac721ec376d07dec3e4/PowerEditor/src/Notepad_plus.rc#L321-L325