### PR TITLE
Remove redundant entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "preview": true,
     "icon": "icon.png",
     "contributes": {
-        "activationEvents": ["*"],
         "keybindings": [
             {
                 "key": "f11",


### PR DESCRIPTION
Remove redundant entry from package.json

This entry is blocking this extension from no reload feature and causing reload required on installation